### PR TITLE
C_BASE_DIR not forcing $HOME

### DIFF
--- a/lambda_toolkit/modules/conf.py
+++ b/lambda_toolkit/modules/conf.py
@@ -82,7 +82,7 @@ class Conf:
             self.log.info("Creating a new config file: '" + self.config_file + "'")
             open(self.config_file, 'a').close()
             self.config.add_section("settings")
-            self.config.set("settings", "C_BASE_DIR", "\"lambda-toolkit/\"")
+            self.config.set("settings", "C_BASE_DIR", "\"~/lambda-toolkit/\"")
             self.config.set("settings", "C_LAMBDAS_DIR", "\"lambdas/\"")
             self.config.set("settings", "C_LAMBDAS_ZIP_DIR", "\".zips/\"")
             self.config.set("settings", "C_LAMBDAPROXY_FUNC", "\"templates/lambda-proxy/index.py\"")

--- a/lambda_toolkit/modules/ltklambdaproxy.py
+++ b/lambda_toolkit/modules/ltklambdaproxy.py
@@ -19,7 +19,7 @@ class Ltklambdaproxy:
         else:
             self.log.critical("Parameter --lambdaname are required.")
 
-        self.base_dir = os.path.join(os.path.expanduser('~'), self.conf.vars['C_BASE_DIR'])
+        self.base_dir = os.path.expanduser(self.conf.vars['C_BASE_DIR'])
         self.lambdas_dir = os.path.join(self.base_dir, self.conf.vars['C_LAMBDAS_DIR'])
         self.lambdaproxy_dir = os.path.join(self.lambdas_dir, self.lambdaname)
         self.lambdaproxy_zip_dir = os.path.join(self.lambdas_dir, self.conf.vars['C_LAMBDAS_ZIP_DIR'])

--- a/lambda_toolkit/modules/project.py
+++ b/lambda_toolkit/modules/project.py
@@ -23,7 +23,7 @@ class Project:
             self.log.critical("Parameter --projectname is required.")
 
         self.lbs = boto3.client('lambda')
-        self.base_dir = os.path.join(os.path.expanduser('~'), self.conf.vars['C_BASE_DIR'])
+        self.base_dir = os.path.expanduser(self.conf.vars['C_BASE_DIR'])
         self.log.info("Projects base dir: " + self.base_dir)
         self.lambdas_dir = os.path.join(self.base_dir, self.conf.vars['C_LAMBDAS_DIR'])
         self.updates_path()

--- a/lambda_toolkit/modules/receiver.py
+++ b/lambda_toolkit/modules/receiver.py
@@ -28,7 +28,7 @@ class Receiver:
         sqs = boto3.resource('sqs')
         queue = sqs.get_queue_by_name(QueueName=self.sqsname)
         self.log.info("Importing project " + self.projectname)
-        pp = os.path.expanduser('~') + "/" + self.conf.vars['C_BASE_DIR'] + "lambdas"
+        pp = os.path.join(os.path.expanduser(self.conf.vars['C_BASE_DIR']), "lambdas")
         sys.path.append(pp)
         lambdas = __import__(self.projectname + ".index")
 


### PR DESCRIPTION
When the _.lambda-toolkit.cfg_ file is create, the _C_BASE_DIR_ variable was forcing **$HOME** as the default; this should not be like this, since it limits the user to always have the project running in is **$HOME**